### PR TITLE
Enhance partners block to display more items

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -94,7 +94,7 @@
 
 <section class="companies">
   {{ with $companies := $data.homepage.companies }}
-  {{ partial "components/homepage/companies" . }}
+    {{ partial "components/homepage/companies" . }}
   {{ end }}
 </section>
 

--- a/layouts/partials/components/homepage/companies.html
+++ b/layouts/partials/components/homepage/companies.html
@@ -26,26 +26,27 @@
   </div>
 </div>
 <div class="container">
-  <div class="row justify-content-between mt-4 no-gutters">
-    {{ range first 3 .items }}
-    <div class="companies__custom d-flex align-items-center my-4">
-      <a href="{{ .url }}" target="_blank">
-        <img src="images/{{ .image }}" class="companies__image"/>
-      </a>
-    </div>
-    {{ end }}
-  </div>
-</div>
-<div class="container">
-  <div class="companies__wrapper mt-0 mt-sm-5">
-    <div class="row justify-content-between no-gutters">
-      {{ range after 3 .items }}
-      <div class="companies__custom d-flex align-items-center my-4">
-        <a href="{{ .url }}" target="_blank">
+  <div class="row mt-4">
+    {{range $index, $items := .items}}
+      <div class="col-xs-12 col-sm-6 col-lg-3 my-4">
+        {{$desktopClasses := newScratch}}
+        {{$tabletClasses := newScratch}}
+
+        {{$desktopClasses.Set "0" "justify-content-lg-start"}}
+        {{$desktopClasses.Set "1" "justify-content-lg-center"}}
+        {{$desktopClasses.Set "2" "justify-content-lg-center"}}
+        {{$desktopClasses.Set "3" "justify-content-lg-end"}}
+
+        {{$tabletClasses.Set "0" "justify-content-sm-start"}}
+        {{$tabletClasses.Set "1" "justify-content-sm-end"}}
+
+        {{$desktopClassName := $desktopClasses.Get (string (mod $index 4))}}
+        {{$tabletClassName := $tabletClasses.Get (string (mod $index 2))}}
+
+        <a href="{{ .url }}" target="_blank" class="d-flex justify-content-center {{$desktopClassName}} {{$tabletClassName}}">
           <img src="images/{{ .image }}" class="companies__image"/>
         </a>
       </div>
-      {{ end }}
-    </div>
+    {{end}}
   </div>
 </div>

--- a/themes/cdap/assets/js/get-started.js
+++ b/themes/cdap/assets/js/get-started.js
@@ -21,7 +21,7 @@ const dropdownProductionItems = document.querySelectorAll('.production-nav-js');
 const dropDownCta = document.querySelector('.dropdown-toggle');
 const panesEvaluation = document.querySelectorAll('.evaluation-wrapper-js');
 const panesProduction = document.querySelectorAll('.production-wrapper-js');
-let persistBtnText = dropDownCta.innerText.trim();
+let persistBtnText = dropDownCta ? dropDownCta.innerText.trim() : '';
 let datasetContext = {};
 
 function handleDropdownItemClick(items, panes, callback) {


### PR DESCRIPTION
* Changed template in the way to display any count of rows sliced by 3
elements for desktop, 2 for tablet and 1 item for mobile
* Fixed js error during dropdown init

Example of more items:

![image](https://user-images.githubusercontent.com/48436532/58358299-01f48e80-7e87-11e9-8b83-67e30de6de10.png)
