### PR TITLE
Add content for 6.5.1 release, remove older/deprecated content

### DIFF
--- a/content/en/get-started/cards/docker-651.md
+++ b/content/en/get-started/cards/docker-651.md
@@ -1,0 +1,15 @@
+### CDAP 6.5.1 for Docker
+
+#### Description
+
+CDAP Docker provides a clean, contained environment for trying out CDAP on your desktop or laptop.
+
+####  What's New:
+
+* View [release notes](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/1729331217/CDAP+Release+6.5.1)
+
+#### System Requirements
+
+* Supported OS: MacOS, RedHat Linux, Ubuntu, CentOS
+* Supported browsers: Chrome
+* Other requirements: Latest version of Docker Toolbox, Apache Maven 3.0+

--- a/content/en/get-started/cards/linux-mac-651.md
+++ b/content/en/get-started/cards/linux-mac-651.md
@@ -1,0 +1,15 @@
+### CDAP 6.5.1 for Linux/Mac
+
+#### Description
+
+CDAP for Linux/MacOSX provides a complete environment for installing and running CDAP on your Linux or MacOSX desktop or laptop.
+
+#### What's New:
+
+* View [release notes](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/1729331217/CDAP+Release+6.5.1)
+
+#### System Requirements
+
+* Supported OS: MacOS, RedHat Linux, Ubuntu, CentOs
+* Supported browsers: Chrome, Safari, Firefox
+* Other requirements: JDK 8, Node.js versions 10.16.2+, Apache Maven 3.0+

--- a/content/en/get-started/cards/vm-651.md
+++ b/content/en/get-started/cards/vm-651.md
@@ -1,0 +1,13 @@
+### CDAP 6.5.1 VM
+
+#### Description
+
+  CDAP VM provides a complete, pre-built environment for running CDAP on your desktop or laptop.
+
+#### What's new
+
+* View [release notes](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/1729331217/CDAP+Release+6.5.1)
+
+#### System Requirements
+
+* Latest version of Oracle Virtualbox

--- a/data/en/get_started.json
+++ b/data/en/get_started.json
@@ -23,21 +23,6 @@
               "img": "/images/pipelines-plugins/google-cloud-platform.png",
               "linkTitle": "Go to Google Cloud Console",
               "link": "https://console.cloud.google.com/data-fusion/"
-            },
-            {
-              "title": " Amazon Web Service",
-              "description": "Spin up a single-process instance of CDAP on AWS Marketplace.",
-              "img": "/images/get-started/amazon-web-services.png",
-              "imgHeight": "70px",
-              "linkTitle": "Go to AWS Marketplace",
-              "link": "https://aws.amazon.com/marketplace/pp/B06W9G8L1C"
-            },
-            {
-              "title": "Microsoft Azure",
-              "description": "Spin up a single-process instance of CDAP on Azure Marketplace.",
-              "img": "/images/pipelines-plugins/microsoft-azure.png",
-              "linkTitle": "Go to Azure Marketplace",
-              "link": "https://azuremarketplace.microsoft.com/en-us/marketplace/apps/cask.cdap-cloud-sandbox"
             }
           ]
         }
@@ -55,13 +40,6 @@
               "linkTitle": "Go to Google Cloud Console",
               "link": "https://console.cloud.google.com/data-fusion/",
               "isFeatured": true
-            },
-            {
-              "title": "CDAP for Amazon EMR",
-              "description": "Installation scripts hosted on Github for running and managing CDAP on an Amazon EMR cluster.",
-              "img": "/images/get-started/amazon-emr.png",
-              "linkTitle": "Get CDAP for Amazon EMR",
-              "link": "https://aws.amazon.com/marketplace/pp/B06W9G8L1C"
             }
           ]
         }
@@ -79,6 +57,49 @@
           "overlayItems": [
             {
               "active": true,
+              "id": "linuxmac-651",
+              "item": {
+                "title": "Linux/Mac OSX",
+                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
+                "img": "/images/get-started/linux-mac.png",
+                "buttons": [
+                  {
+                    "buttonTitle": "CDAP 6.5.1 for Linux/Mac",
+                    "id": "version-651-mac",
+                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox/cdap-sandbox-6.5.1.zip"
+                  }
+                ],
+                "dropdownItems": [
+                  {
+                    "active": true,
+                    "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                    "id": "linuxmac-651"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.5.0 Linux/Mac",
+                    "id": "linuxmac-650"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.4.1 Linux/Mac",
+                    "id": "linuxmac-641"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.3.0 Linux/Mac",
+                    "id": "linuxmac-630"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.2.3 Linux/Mac",
+                    "id": "linuxmac-623"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.1.4 Linux/Mac",
+                    "id": "linuxmac-614"
+                  }
+                ]
+              },
+              "details": "content/en/get-started/cards/linux-mac-651.md"
+            },
+            {
               "id": "linuxmac-650",
               "item": {
                 "title": "Linux/Mac OSX",
@@ -92,6 +113,10 @@
                   }
                 ],
                 "dropdownItems": [
+                  {
+                    "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                    "id": "linuxmac-651"
+                  },
                   {
                     "active": true,
                     "linkTitle": "CDAP 6.5.0 Linux/Mac",
@@ -112,18 +137,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Linux/Mac",
                     "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
                   }
                 ]
               },
@@ -144,6 +157,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                    "id": "linuxmac-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Linux/Mac",
                     "id": "linuxmac-650"
                   },
@@ -163,18 +180,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Linux/Mac",
                     "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
                   }
                 ]
               },
@@ -195,6 +200,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                    "id": "linuxmac-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Linux/Mac",
                     "id": "linuxmac-650"
                   },
@@ -214,18 +223,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Linux/Mac",
                     "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
                   }
                 ]
               },
@@ -246,6 +243,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                    "id": "linuxmac-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Linux/Mac",
                     "id": "linuxmac-650"
                   },
@@ -265,18 +266,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Linux/Mac",
                     "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
                   }
                 ]
               },
@@ -297,6 +286,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                    "id": "linuxmac-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Linux/Mac",
                     "id": "linuxmac-650"
                   },
@@ -316,177 +309,52 @@
                     "active": true,
                     "linkTitle": "CDAP 6.1.4 Linux/Mac",
                     "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
                   }
                 ]
               },
               "details": "content/en/get-started/cards/linux-mac-614.md"
             },
             {
-              "id": "linuxmac-600",
+              "id": "vm-651",
               "item": {
-                "title": "Linux/Mac OSX",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/linux-mac.png",
+                "title": "CDAP for VM",
+                "img": "/images/get-started/vm.svg",
                 "buttons": [
                   {
-                    "buttonTitle": "CDAP 6.0.0 for Linux/Mac",
-                    "id": "version-600-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox/cdap-sandbox-6.0.0.zip"
+                    "buttonTitle": "CDAP 6.5.1 for VM",
+                    "id": "version-651-vm",
+                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox-vm/cdap-sandbox-6.5.1.ova"
                   }
                 ],
                 "dropdownItems": [
                   {
-                    "linkTitle": "CDAP 6.5.0 Linux/Mac",
-                    "id": "linuxmac-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 Linux/Mac",
-                    "id": "linuxmac-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 Linux/Mac",
-                    "id": "linuxmac-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 Linux/Mac",
-                    "id": "linuxmac-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 Linux/Mac",
-                    "id": "linuxmac-614"
-                  },
-                  {
                     "active": true,
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
+                    "linkTitle": "CDAP 6.5.1 VM",
+                    "id": "vm-651"
                   },
                   {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
+                    "linkTitle": "CDAP 6.5.0 VM",
+                    "id": "vm-650"
                   },
                   {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
+                    "linkTitle": "CDAP 6.4.1 VM",
+                    "id": "vm-641"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.3.0 VM",
+                    "id": "vm-630"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.2.3 VM",
+                    "id": "vm-623"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.1.4 VM",
+                    "id": "vm-614"
                   }
                 ]
               },
-              "details": "content/en/get-started/cards/linux-mac-600.md"
-            },
-            {
-              "id": "linuxmac-512",
-              "item": {
-                "title": "Linux/Mac OSX",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/linux-mac.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 5.1.2 for Linux/Mac",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox/cdap-sandbox-5.1.2.zip"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 Linux/Mac",
-                    "id": "linuxmac-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 Linux/Mac",
-                    "id": "linuxmac-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 Linux/Mac",
-                    "id": "linuxmac-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 Linux/Mac",
-                    "id": "linuxmac-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 Linux/Mac",
-                    "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/linux-mac-512.md"
-            },
-            {
-              "id": "linuxmac-435",
-              "item": {
-                "title": "Linux/Mac OSX",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/linux-mac.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 4.3.5 for Linux/Mac",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox/cdap-sandbox-4.3.5.zip"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 Linux/Mac",
-                    "id": "linuxmac-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 Linux/Mac",
-                    "id": "linuxmac-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 Linux/Mac",
-                    "id": "linuxmac-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 Linux/Mac",
-                    "id": "linuxmac-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 Linux/Mac",
-                    "id": "linuxmac-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Linux/Mac",
-                    "id": "linuxmac-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Linux/Mac",
-                    "id": "linuxmac-512"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 4.3.5 Linux/Mac",
-                    "id": "linuxmac-435"
-                  }
-                ],
-                "linkTitle": "Get CDAP for Linux/Mac",
-                "linkId": "linux"
-              },
-              "details": "content/en/get-started/cards/linux-mac-435.md"
+              "details": "content/en/get-started/cards/vm-651.md"
             },
             {
               "id": "vm-650",
@@ -501,6 +369,10 @@
                   }
                 ],
                 "dropdownItems": [
+                  {
+                    "linkTitle": "CDAP 6.5.1 VM",
+                    "id": "vm-651"
+                  },
                   {
                     "active": true,
                     "linkTitle": "CDAP 6.5.0 VM",
@@ -521,18 +393,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 VM",
                     "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
                   }
                 ]
               },
@@ -552,6 +412,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 VM",
+                    "id": "vm-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 VM",
                     "id": "vm-650"
                   },
@@ -571,18 +435,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 VM",
                     "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
                   }
                 ]
               },
@@ -602,6 +454,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 VM",
+                    "id": "vm-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 VM",
                     "id": "vm-650"
                   },
@@ -621,18 +477,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 VM",
                     "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
                   }
                 ]
               },
@@ -652,6 +496,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 VM",
+                    "id": "vm-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 VM",
                     "id": "vm-650"
                   },
@@ -671,18 +519,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 VM",
                     "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
                   }
                 ]
               },
@@ -702,6 +538,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 VM",
+                    "id": "vm-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 VM",
                     "id": "vm-650"
                   },
@@ -721,173 +561,53 @@
                     "active": true,
                     "linkTitle": "CDAP 6.1.4 VM",
                     "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
                   }
                 ]
               },
               "details": "content/en/get-started/cards/vm-614.md"
             },
             {
-              "id": "vm-600",
+              "id": "docker-651",
               "item": {
-                "title": "CDAP for VM",
-                "img": "/images/get-started/vm.svg",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.0.0 for VM",
-                    "id": "version-600-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox-vm/cdap-sandbox-6.0.0.ova"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 VM",
-                    "id": "vm-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 VM",
-                    "id": "vm-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 VM",
-                    "id": "vm-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 VM",
-                    "id": "vm-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 VM",
-                    "id": "vm-614"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/vm-600.md"
-            },
-            {
-              "id": "vm-512",
-              "item": {
-                "title": "CDAP for VM",
-                "img": "/images/get-started/vm.svg",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 5.1.2 for VM",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox-vm/cdap-sandbox-5.1.2.ova"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 VM",
-                    "id": "vm-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 VM",
-                    "id": "vm-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 VM",
-                    "id": "vm-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 VM",
-                    "id": "vm-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 VM",
-                    "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/vm-512.md"
-            },
-            {
-              "id": "vm-435",
-              "item": {
-                "title": "CDAP for VM",
+                "title": "CDAP for Docker",
                 "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/vm.svg",
+                "img": "/images/get-started/docker.png",
                 "buttons": [
                   {
-                    "buttonTitle": "CDAP 4.3.5 for VM",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-sandbox-vm/cdap-sandbox-4.3.5.ova"
+                    "buttonTitle": "CDAP 6.5.1 for Docker",
+                    "id": "version-651-docker",
+                    "buttonHref": "https://hub.docker.com/r/caskdata/cdap-sandbox/"
                   }
                 ],
                 "dropdownItems": [
                   {
-                    "linkTitle": "CDAP 6.5.0 VM",
-                    "id": "vm-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 VM",
-                    "id": "vm-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 VM",
-                    "id": "vm-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 VM",
-                    "id": "vm-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 VM",
-                    "id": "vm-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 VM",
-                    "id": "vm-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 VM",
-                    "id": "vm-512"
-                  },
-                  {
                     "active": true,
-                    "linkTitle": "CDAP 4.3.5 VM",
-                    "id": "vm-435"
+                    "linkTitle": "CDAP 6.5.1 Docker",
+                    "id": "docker-651"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.5.0 Docker",
+                    "id": "docker-650"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.4.1 Docker",
+                    "id": "docker-641"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.3.0 Docker",
+                    "id": "docker-630"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.2.3 Docker",
+                    "id": "docker-623"
+                  },
+                  {
+                    "linkTitle": "CDAP 6.1.4 Docker",
+                    "id": "docker-614"
                   }
                 ]
               },
-              "details": "content/en/get-started/cards/vm-435.md"
+              "details": "content/en/get-started/cards/docker-651.md"
             },
             {
               "id": "docker-650",
@@ -903,6 +623,10 @@
                   }
                 ],
                 "dropdownItems": [
+                  {
+                    "linkTitle": "CDAP 6.5.1 Docker",
+                    "id": "docker-651"
+                  },
                   {
                     "active": true,
                     "linkTitle": "CDAP 6.5.0 Docker",
@@ -923,18 +647,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Docker",
                     "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
                   }
                 ]
               },
@@ -955,6 +667,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Docker",
+                    "id": "docker-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Docker",
                     "id": "docker-650"
                   },
@@ -974,18 +690,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Docker",
                     "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
                   }
                 ]
               },
@@ -1006,6 +710,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Docker",
+                    "id": "docker-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Docker",
                     "id": "docker-650"
                   },
@@ -1025,18 +733,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Docker",
                     "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
                   }
                 ]
               },
@@ -1057,6 +753,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Docker",
+                    "id": "docker-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Docker",
                     "id": "docker-650"
                   },
@@ -1076,18 +776,6 @@
                   {
                     "linkTitle": "CDAP 6.1.4 Docker",
                     "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
                   }
                 ]
               },
@@ -1108,6 +796,10 @@
                 ],
                 "dropdownItems": [
                   {
+                    "linkTitle": "CDAP 6.5.1 Docker",
+                    "id": "docker-651"
+                  },
+                  {
                     "linkTitle": "CDAP 6.5.0 Docker",
                     "id": "docker-650"
                   },
@@ -1127,175 +819,10 @@
                     "active": true,
                     "linkTitle": "CDAP 6.1.4 Docker",
                     "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
                   }
                 ]
               },
               "details": "content/en/get-started/cards/docker-614.md"
-            },
-            {
-              "id": "docker-600",
-              "item": {
-                "title": "CDAP for Docker",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/docker.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.0.0 for Docker",
-                    "id": "version-600-mac",
-                    "buttonHref": "https://hub.docker.com/r/caskdata/cdap-sandbox/"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 Docker",
-                    "id": "docker-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 Docker",
-                    "id": "docker-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 Docker",
-                    "id": "docker-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 Docker",
-                    "id": "docker-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 Docker",
-                    "id": "docker-614"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/docker-600.md"
-            },
-            {
-              "id": "docker-512",
-              "item": {
-                "title": "CDAP for Docker",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/docker.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 5.1.2 for Docker",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://hub.docker.com/r/caskdata/cdap-sandbox/"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 Docker",
-                    "id": "docker-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 Docker",
-                    "id": "docker-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 Docker",
-                    "id": "docker-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 Docker",
-                    "id": "docker-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 Docker",
-                    "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/docker-512.md"
-            },
-            {
-              "id": "docker-435",
-              "item": {
-                "title": "CDAP for Docker",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/docker.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 4.3.5 for Docker",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://hub.docker.com/r/caskdata/cdap-sandbox/"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.5.0 Docker",
-                    "id": "docker-650"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.4.1 Docker",
-                    "id": "docker-641"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.3.0 Docker",
-                    "id": "docker-630"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.2.3 Docker",
-                    "id": "docker-623"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.1.4 Docker",
-                    "id": "docker-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Docker",
-                    "id": "docker-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Docker",
-                    "id": "docker-512"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 4.3.5 Docker",
-                    "id": "docker-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/docker-435.md"
             }
           ],
           "items": [
@@ -1304,16 +831,16 @@
               "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
               "img": "/images/get-started/linux-mac.png",
               "button": {
-                "buttonTitle": "CDAP 6.5.0 for Linux/Mac",
-                "id": "version-650-mac",
-                "buttonHref": "https://downloads.cdap.io/cdap-sandbox/cdap-sandbox-6.5.0.zip"
+                "buttonTitle": "CDAP 6.5.1 for Linux/Mac",
+                "id": "version-651-mac",
+                "buttonHref": "https://downloads.cdap.io/cdap-sandbox/cdap-sandbox-6.5.1.zip"
               },
               "linkTitle": "Get CDAP for Linux/Mac",
-              "linkId": "linuxmac-650",
+              "linkId": "linuxmac-651",
               "overlayPane": {
-                "id": "version-650-mac",
-                "linkTitle": "CDAP 6.5.0 Linux/Mac",
-                "title": "CDAP 6.5.0 for Linux/Mac"
+                "id": "version-651-mac",
+                "linkTitle": "CDAP 6.5.1 Linux/Mac",
+                "title": "CDAP 6.5.1 for Linux/Mac"
               }
             },
             {
@@ -1322,16 +849,16 @@
               "img": "/images/get-started/vm.svg",
               "buttons": {
                 "active": true,
-                "buttonTitle": "CDAP 6.5.0 for VM",
-                "id": "version-650-vm",
-                "buttonHref": "https://downloads.cdap.io/cdap-sandbox-vm/cdap-sandbox-6.5.0.ova"
+                "buttonTitle": "CDAP 6.5.1 for VM",
+                "id": "version-651-vm",
+                "buttonHref": "https://downloads.cdap.io/cdap-sandbox-vm/cdap-sandbox-6.5.1.ova"
               },
               "linkTitle": "Get CDAP for VM",
-              "linkId": "vm-650",
+              "linkId": "vm-651",
               "overlayPane": {
-                "id": "version-650-vm",
-                "linkTitle": "CDAP 6.5.0 VM",
-                "title": "CDAP 6.5.0 for VM"
+                "id": "version-651-vm",
+                "linkTitle": "CDAP 6.5.1 VM",
+                "title": "CDAP 6.5.1 for VM"
               }
             },
             {
@@ -1340,521 +867,17 @@
               "img": "/images/get-started/docker.png",
               "buttons": {
                 "active": true,
-                "id": "version-650-docker",
-                "buttonTitle": "Get CDAP 6.5.0 for Docker",
+                "id": "version-651-docker",
+                "buttonTitle": "Get CDAP 6.5.1 for Docker",
                 "buttonHref": "https://hub.docker.com/r/caskdata/cdap-sandbox/"
               },
               "linkTitle": "Get CDAP for Docker",
-              "linkId": "docker-650",
+              "linkId": "docker-651",
               "link": "",
               "overlayPane": {
-                "id": "version-650-docker",
-                "linkTitle": "CDAP 6.5.0 Docker",
-                "title": "CDAP 6.5.0 for Linux/Mac"
-              }
-            }
-          ]
-        }
-      ],
-      "onProduction": [
-        {
-          "subTitle": "Production",
-          "title": "Get connected",
-          "description": "If you are ready to install CDAP on your Apache Hadoop clusters, in critical environments, choose from one of the following options:",
-          "overlay": true,
-          "overlayItems": [
-            {
-              "active": true,
-              "id": "cloudera-614",
-              "title": "CDAP 6.1.4 for CDH",
-              "description": "CDAP for Linux/MacOSX provides a complete environment for installing and running CDAP on your Linux or MacOSX desktop or laptop.",
-              "item": {
-                "title": "CDAP for CDH",
-                "img": "/images/get-started/cdh.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.1.4 for CDH",
-                    "id": "version-614-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-csd/CDAP-6.1.0.jar"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.1.4 CDH",
-                    "id": "cloudera-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 CDH",
-                    "id": "cloudera-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 CDH",
-                    "id": "cloudera-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 CDH",
-                    "id": "cloudera-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/cdh-614.md"
-            },
-            {
-              "id": "cloudera-600",
-              "title": "CDAP 6.0.0 for CDH",
-              "description": "CDAP for Linux/MacOSX provides a complete environment for installing and running CDAP on your Linux or MacOSX desktop or laptop.",
-              "item": {
-                "title": "CDAP for CDH",
-                "img": "/images/get-started/cdh.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.0.0 for CDH",
-                    "id": "version-600-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-csd/CDAP-6.0.0.jar"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 CDH",
-                    "id": "cloudera-614"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.0.0 CDH",
-                    "id": "cloudera-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 CDH",
-                    "id": "cloudera-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 CDH",
-                    "id": "cloudera-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/cdh-600.md"
-            },
-            {
-              "id": "cloudera-512",
-              "title": "CDAP 5.1.2 for Linux/Mac",
-              "description": "CDAP for Linux/MacOSX provides a complete environment for installing and running CDAP on your Linux or MacOSX desktop or laptop.",
-              "item": {
-                "title": "CDAP for CDH",
-                "img": "/images/get-started/cdh.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 5.1.2 for CDH",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-csd/CDAP-5.1.0.jar"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 CDH",
-                    "id": "cloudera-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 CDH",
-                    "id": "cloudera-600"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 5.1.2 CDH",
-                    "id": "cloudera-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 CDH",
-                    "id": "cloudera-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/cdh-512.md"
-            },
-            {
-              "id": "cloudera-435",
-              "item": {
-                "title": "CDAP for CDH",
-                "description": "Download a standalone zip file for trying out CDAP on your Linux or Mac OSX machine.",
-                "img": "/images/get-started/cdh.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 4.3.5 for CDH",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://downloads.cdap.io/cdap-csd/CDAP-4.3.1.jar"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 CDH",
-                    "id": "cloudera-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 CDH",
-                    "id": "cloudera-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 CDH",
-                    "id": "cloudera-512"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 4.3.5 CDH",
-                    "id": "cloudera-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/cdh-435.md"
-            },
-            {
-              "id": "ambari-614",
-              "item": {
-                "title": "CDAP for Ambari",
-                "img": "/images/get-started/ambari.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.1.4 for Ambari DEB",
-                    "id": "version-614-mac",
-                    "buttonHref": "https://repository.cdap.io/ubuntu/precise/amd64/cdap/6.1/pool/precise/cdap/c/cdap-ambari-service/cdap-ambari-service_6.1.4-1_all.deb"
-                  },
-                  {
-                    "buttonTitle": "CDAP 6.1.4 for Ambari RPM",
-                    "id": "version-614-mac",
-                    "buttonHref": "https://repository.cdap.io/centos/6/x86_64/cdap/6.1/rpms/cdap-ambari-service-6.1.4-1.noarch.rpm"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.1.4 Ambari",
-                    "id": "ambari-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Ambari",
-                    "id": "ambari-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Ambari",
-                    "id": "ambari-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Ambari",
-                    "id": "ambari-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/ambari-614.md"
-            },
-            {
-              "id": "ambari-600",
-              "item": {
-                "title": "CDAP for Ambari",
-                "img": "/images/get-started/ambari.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.0.0 for Ambari DEB",
-                    "id": "version-600-mac",
-                    "buttonHref": "https://repository.cdap.io/ubuntu/precise/amd64/cdap/6.0/pool/precise/cdap/c/cdap-ambari-service/cdap-ambari-service_6.0.0-1_all.deb"
-                  },
-                  {
-                    "buttonTitle": "CDAP 6.0.0 for Ambari RPM",
-                    "id": "version-600-mac",
-                    "buttonHref": "https://repository.cdap.io/centos/6/x86_64/cdap/6.0/rpms/cdap-ambari-service-6.0.0-1.noarch.rpm"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 Ambari",
-                    "id": "ambari-614"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.0.0 Ambari",
-                    "id": "ambari-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Ambari",
-                    "id": "ambari-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Ambari",
-                    "id": "ambari-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/ambari-600.md"
-            },
-            {
-              "id": "ambari-512",
-              "item": {
-                "title": "CDAP for Ambari",
-                "img": "/images/get-started/ambari.png",
-                "buttons": [
-
-                  {
-                    "buttonTitle": "CDAP 5.1.2 for Ambari DEB",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://repository.cdap.io/ubuntu/precise/amd64/cdap/5.1/pool/precise/cdap/c/cdap-ambari-service/cdap-ambari-service_5.1.0-1_all.deb"
-                  },
-                  {
-                    "buttonTitle": "CDAP 5.1.2 for Ambari RPM",
-                    "id": "version-512-mac",
-                    "buttonHref": "https://repository.cdap.io/centos/6/x86_64/cdap/5.1/rpms/cdap-ambari-service-5.1.0-1.noarch.rpm"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 Ambari",
-                    "id": "ambari-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Ambari",
-                    "id": "ambari-600"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 5.1.2 Ambari",
-                    "id": "ambari-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 Ambari",
-                    "id": "ambari-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/ambari-512.md"
-            },
-            {
-              "id": "ambari-435",
-              "item": {
-                "title": "CDAP for Ambari",
-                "img": "/images/get-started/ambari.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 4.3.5 for Ambari DEB",
-                    "buttonHref": "https://repository.cdap.io/ubuntu/precise/amd64/cdap/4.3/pool/precise/cdap/c/cdap-ambari-service/cdap-ambari-service_4.3.0-1_all.deb"
-                  },
-                  {
-                    "buttonTitle": "CDAP 4.3.5 for Ambari RPM",
-                    "buttonHref": "https://repository.cdap.io/centos/6/x86_64/cdap/4.3/rpms/cdap-ambari-service-4.3.0-1.noarch.rpm"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 Ambari",
-                    "id": "ambari-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 Ambari",
-                    "id": "ambari-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 Ambari",
-                    "id": "ambari-512"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 4.3.5 Ambari",
-                    "id": "ambari-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/ambari-435.md"
-            },
-            {
-              "id": "mapr-614",
-              "item": {
-                "title": "CDAP for MapR",
-                "img": "/images/get-started/mapr.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.1.4 DEB",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-deb-bundle/cdap-distributed-deb-bundle-6.1.4.tgz"
-                  },
-                  {
-                    "buttonTitle": "CDAP 6.1.4 RPM",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-rpm-bundle/cdap-distributed-rpm-bundle-6.1.4.tgz"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.1.4 MapR",
-                    "id": "mapr-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 MapR",
-                    "id": "mapr-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 MapR",
-                    "id": "mapr-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 MapR",
-                    "id": "mapr-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/mapr-614.md"
-            },
-            {
-              "id": "mapr-600",
-              "item": {
-                "title": "CDAP for MapR",
-                "img": "/images/get-started/mapr.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 6.0.0 DEB",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-deb-bundle/cdap-distributed-deb-bundle-6.0.0.tgz"
-                  },
-                  {
-                    "buttonTitle": "CDAP 6.0.0 RPM",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-rpm-bundle/cdap-distributed-rpm-bundle-6.0.0.tgz"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 MapR",
-                    "id": "mapr-614"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 6.0.0 MapR",
-                    "id": "mapr-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 MapR",
-                    "id": "mapr-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 MapR",
-                    "id": "mapr-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/mapr-600.md"
-            },
-            {
-              "id": "mapr-512",
-              "item": {
-                "title": "CDAP for MapR",
-                "img": "/images/get-started/mapr.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 5.1.2 DEB",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-deb-bundle/cdap-distributed-deb-bundle-5.1.2.tgz"
-                  },
-                  {
-                    "buttonTitle": "CDAP 5.1.2 RPM",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-rpm-bundle/cdap-distributed-rpm-bundle-5.1.2.tgz"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 MapR",
-                    "id": "mapr-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 MapR",
-                    "id": "mapr-600"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 5.1.2 MapR",
-                    "id": "mapr-512"
-                  },
-                  {
-                    "linkTitle": "CDAP 4.3.5 MapR",
-                    "id": "mapr-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/mapr-512.md"
-            },
-            {
-              "id": "mapr-435",
-              "item": {
-                "title": "CDAP for MapR",
-                "img": "/images/get-started/mapr.png",
-                "buttons": [
-                  {
-                    "buttonTitle": "CDAP 4.3.5 DEB",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-deb-bundle/cdap-distributed-deb-bundle-4.3.5.tgz"
-                  },
-                  {
-                    "buttonTitle": "CDAP 4.3.5 RPM",
-                    "buttonHref": "https://downloads.cdap.io/cdap-distributed-rpm-bundle/cdap-distributed-rpm-bundle-4.3.5.tgz"
-                  }
-                ],
-                "dropdownItems": [
-                  {
-                    "linkTitle": "CDAP 6.1.4 MapR",
-                    "id": "mapr-614"
-                  },
-                  {
-                    "linkTitle": "CDAP 6.0.0 MapR",
-                    "id": "mapr-600"
-                  },
-                  {
-                    "linkTitle": "CDAP 5.1.2 MapR",
-                    "id": "mapr-512"
-                  },
-                  {
-                    "active": true,
-                    "linkTitle": "CDAP 4.3.5 MapR",
-                    "id": "mapr-435"
-                  }
-                ]
-              },
-              "details": "content/en/get-started/cards/mapr-435.md"
-            }
-          ],
-          "items": [
-            {
-              "title": "CDAP for CDH",
-              "description": "To add CDAP to your Cloudera Manager installations, use the CDAP Custom Service Descriptor (CSD).",
-              "img": "/images/get-started/cdh.png",
-              "button": {
-                "id": "version-614-cdh",
-                "buttonTitle": "CDAP 6.1.4 for CDH",
-                "buttonHref": "https://downloads.cdap.io/cdap-csd/CDAP-6.1.0.jar"
-              },
-              "linkTitle": "Get CDAP for CDH",
-              "linkId": "cloudera-614",
-              "link": "",
-              "overlayPane": {
-                "id": "cloudera-614",
-                "linkTitle": "CDAP 6.1.4 CDH",
-                "title": "CDAP 6.1.4 for CDH",
-                "active": true
-              }
-            },
-            {
-              "title": "CDAP for Ambari",
-              "description": "To use CDAP within your Hortonworks Data Platform (HDP) environment, use Apache Ambari.",
-              "img": "/images/get-started/ambari.png",
-              "linkTitle": "Get CDAP for Ambari",
-              "linkId": "ambari-614",
-              "link": "",
-              "overlay_pane": {
-                "id": "version-614-am",
-                "linkTitle": "CDAP 6.1.4 Ambari",
-                "title": "CDAP 6.1.4 for Ambari"
-              }
-            },
-            {
-              "title": "CDAP for Apache Hadoop",
-              "description": "If you are using MapR, BigTop or the Apache Hadoop, use RPM and Debian distributions of CDAP.",
-              "img": "/images/get-started/mapr.png",
-              "linkTitle": "Get CDAP for RPM/DEB",
-              "linkId": "mapr-614",
-              "link": "",
-              "overlayPane": {
-                "id": "version-614-mapr",
-                "linkTitle": "CDAP 6.1.4 MapR",
-                "title": "CDAP 6.1.4 for MapR"
+                "id": "version-651-docker",
+                "linkTitle": "CDAP 6.5.1 Docker",
+                "title": "CDAP 6.5.1 for Linux/Mac"
               }
             }
           ]

--- a/data/en/news.json
+++ b/data/en/news.json
@@ -3,8 +3,8 @@
     {
       "active": true,
       "imageUrl": "/images/logo-orange.png",
-      "title": "CDAP 6.5.0",
-      "description": "CDAP version 6.5.0 is generally available.",
+      "title": "CDAP 6.5.1",
+      "description": "CDAP version 6.5.1 is generally available.",
       "linkTitle": "Get Started",
       "linkUrl": "/get-started/"
     },


### PR DESCRIPTION
- Add content for 6.5.1 and make it active.
- Fix for CDAP-18417
   - Remove the deprecation evaluation links for AWS and Azure.
   - Remove the "PRODUCTION" section on the "Get started" "On Premises" tab. 
   - Remove the CDAP for EMR link
   - Remove any version < 6.1.x